### PR TITLE
Auto generate gitignore

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,5 +109,5 @@ PLATFORMS
 
 DEPENDENCIES
   box_cutter!
-  pry
+  pry (~> 0.10)
   rspec (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       tzinfo (~> 1.1)
     arel (5.0.1.20140414130214)
     builder (3.2.2)
+    coderay (1.1.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     hike (1.2.3)
@@ -44,10 +45,15 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    method_source (0.8.2)
     mime-types (1.25.1)
     minitest (5.4.0)
     multi_json (1.10.1)
     polyglot (0.3.5)
+    pry (0.10.0)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -79,6 +85,7 @@ GEM
     rspec-mocks (3.0.3)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.3)
+    slop (3.6.0)
     sprockets (2.12.1)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -94,7 +101,7 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (1.2.1)
+    tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -102,4 +109,5 @@ PLATFORMS
 
 DEPENDENCIES
   box_cutter!
+  pry
   rspec (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Box Cutter
 ![ScreenShot](box_cutter.jpg)
 [//]: # (Image by Evan-Amos taken from http://commons.wikimedia.org/wiki/File:Box-cutter.jpg)
-
+[![Code Climate](https://codeclimate.com/github/smashingboxes/box_cutter/badges/gpa.svg)](https://codeclimate.com/github/smashingboxes/box_cutter)
+[![Test Coverage](https://codeclimate.com/github/smashingboxes/box_cutter/badges/coverage.svg)](https://codeclimate.com/github/smashingboxes/box_cutter)
 ## Pre-release TODO
 * [ ] Add Travis (.yml and badge)
 * [ ] Add Code Climate (Test coverage with Travis and badge)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Test Coverage](https://codeclimate.com/github/smashingboxes/box_cutter/badges/coverage.svg)](https://codeclimate.com/github/smashingboxes/box_cutter)
 ## Pre-release TODO
 * [ ] Add Travis (.yml and badge)
-* [ ] Add Code Climate (Test coverage with Travis and badge)
+* [x] Add Code Climate (Test coverage with Travis and badge)
 * [ ] Improve Box Cutter's README
 * [ ] Set PostreSQL as default
 * [ ] Skip test unit by default
@@ -23,7 +23,7 @@
 * [x] Discuss adding Foundation (See [#7](https://github.com/smashingboxes/box_cutter/issues/7))
 * [ ] Discuss changing default application.js to application.coffee (See [#8](https://github.com/smashingboxes/box_cutter/issues/8))
 * [ ] Change default application.css to application.sass (or scss?) ((See [#9](https://github.com/smashingboxes/box_cutter/issues/9))
-* [ ] Add Github's Rails.gitignore
+* [x] Add Github's Rails.gitignore
 * [ ] Set Mailer for staging, and production
 * [ ] Skip bundle and do a `bundle update` at a later step
 * [ ] Add a Sitemap Generator and a robots.txt

--- a/box_cutter.gemspec
+++ b/box_cutter.gemspec
@@ -30,4 +30,5 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.add_dependency 'rails', BoxCutter::RAILS_VERSION
 
   s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'pry'
 end

--- a/box_cutter.gemspec
+++ b/box_cutter.gemspec
@@ -30,5 +30,5 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.add_dependency 'rails', BoxCutter::RAILS_VERSION
 
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry',   '~> 0.10'
 end

--- a/lib/box_cutter/app_builder.rb
+++ b/lib/box_cutter/app_builder.rb
@@ -5,8 +5,7 @@ module BoxCutter
     end
 
     def gitignore
-      remove_file '.gitignore'
-      copy_file 'boxcutter_gitignore', '.gitignore'
+      template 'boxcutter_gitignore', '.gitignore'
     end
 
     # def set_ruby_to_version_being_used

--- a/lib/box_cutter/app_builder.rb
+++ b/lib/box_cutter/app_builder.rb
@@ -4,6 +4,11 @@ module BoxCutter
       template 'README.md.erb', 'README.md'
     end
 
+    def gitignore
+      remove_file '.gitignore'
+      copy_file 'boxcutter_gitignore', '.gitignore'
+    end
+
     # def set_ruby_to_version_being_used
     #   create_file '.ruby-version', "#{BoxCutter::RUBY_VERSION}\n"
     # end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -8,4 +8,12 @@ describe 'Box cut a new project with default configuration' do
 
     expect(readme_file).to match(/Dummy/)
   end
+
+  it 'generates a .gitignore for rails' do
+    cut_the_box
+
+    actual   = IO.read("#{project_path}/.gitignore")
+    expected = IO.read("templates/boxcutter_gitignore")
+    expect(actual).to eq(expected)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'bundler/setup'
 
 Bundler.require(:default, :test)

--- a/templates/boxcutter_gitignore
+++ b/templates/boxcutter_gitignore
@@ -1,0 +1,27 @@
+# Find me in templates/boxcutter_gitignore
+*.rbc
+capybara-*.html
+.rspec
+/log
+/tmp
+/db/*.sqlite3
+/public/system
+/coverage/
+/spec/tmp
+**.orig
+rerun.txt
+pickle-email-*.html
+
+# TODO Comment out these rules if you are OK with secrets being uploaded to the repo
+config/initializers/secret_token.rb
+config/secrets.yml
+
+## Environment normalisation:
+/.bundle
+/vendor/bundle
+
+# these should all be checked in to normalise the environment:
+# Gemfile.lock, .ruby-version, .ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc


### PR DESCRIPTION
# Why?
- Needed a rails gitignore in genrated projects
- Needed code climate
- Needed pry as a development dependency
# What changed?
- Added `templates/boxcutter_gitignore`. This is a base file that we can modify when needed.
- Added little fixes to readme, etc
- Specs
